### PR TITLE
Update based on template suggested by AWS

### DIFF
--- a/project/cloudformation_templates/config_dependencies.yml
+++ b/project/cloudformation_templates/config_dependencies.yml
@@ -135,7 +135,7 @@ Resources:
           Principal:
             Service: [config.amazonaws.com]
           Action: ['sts:AssumeRole']
-      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSConfigRole']
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWS_ConfigRole']
       Policies:
       - PolicyName: root
         PolicyDocument:


### PR DESCRIPTION
https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/#:~:text=On%20July%205%2C%202022%2C%20the%20AWS%20managed%20policy%20AWSConfigRole%20will%20be%20deprecated.